### PR TITLE
Fix a case when new BigDecimal(String) constructor raises an error due to the fact that resulting string is equal to a single dot.

### DIFF
--- a/src/main/java/com/linuxense/javadbf/DBFUtils.java
+++ b/src/main/java/com/linuxense/javadbf/DBFUtils.java
@@ -65,7 +65,11 @@ public final class DBFUtils {
 			}
 			t_float = DBFUtils.removeSpaces(t_float);
 			if (t_float.length > 0 && DBFUtils.isPureAscii(t_float) && !DBFUtils.contains(t_float, (byte) '?') && !DBFUtils.contains(t_float, (byte) '*')) {
-				return new BigDecimal(new String(t_float, StandardCharsets.US_ASCII).replace(',', '.'));
+				String aux = new String(t_float, StandardCharsets.US_ASCII).replace(',', '.');
+				if (aux.compareTo(".") == 0) {
+					return BigDecimal.ZERO;
+				}
+				return new BigDecimal(aux);
 			} else {
 				return null;
 			}


### PR DESCRIPTION
Hello,

I have a DBF file that causes the above error.

Do you think this fix make sense?

Thanks,