### PR TITLE
Add option to disable extended (2-byte length) character fields

### DIFF
--- a/src/main/java/com/linuxense/javadbf/DBFField.java
+++ b/src/main/java/com/linuxense/javadbf/DBFField.java
@@ -166,11 +166,12 @@ public class DBFField {
 	 * @param in DataInputStream
 	 * @param charset charset to use
 	 * @param useFieldFlags If the file can store field flags (setting this to false ignore any data in byes 18-19)
+         * @param supportExtendedCharacterFields True if 2-byte (extended) length character fields should be supported, see adjustLengthForLongCharSupport()
 	 *
 	 * @return Returns the created DBFField object.
 	 * @throws IOException  If any stream reading problems occures.
 	 */
-	protected static DBFField createField(DataInput in, Charset charset, boolean useFieldFlags) throws IOException {
+	protected static DBFField createField(DataInput in, Charset charset, boolean useFieldFlags, boolean supportExtendedCharacterFields) throws IOException {
 
 		DBFField field = new DBFField();
 
@@ -203,8 +204,9 @@ public class DBFField {
 		field.setFieldsFlag = in.readByte(); /* 23 */
 		in.readFully(field.reserv4); /* 24-30 */
 		field.indexFieldFlag = in.readByte(); /* 31 */
-		adjustLengthForLongCharSupport(field);
-		
+		if (supportExtendedCharacterFields){
+			adjustLengthForLongCharSupport(field);
+		}
 		if (!useFieldFlags) {
 			field.reserv2 = 0;
 		}
@@ -212,7 +214,7 @@ public class DBFField {
 		return field;
 	}
 
-	protected static DBFField createFieldDB7(DataInput in, Charset charset) throws IOException {
+	protected static DBFField createFieldDB7(DataInput in, Charset charset, boolean supportExtendedCharacterFields) throws IOException {
 
 		DBFField field = new DBFField();
 
@@ -243,8 +245,9 @@ public class DBFField {
 		field.reserv3 = DBFUtils.readLittleEndianShort(in); /* 38-39 */
 		in.readInt(); // 40-43 nextAuto
 		in.readInt(); // 44-47 reserv
-
-		adjustLengthForLongCharSupport(field);
+		if (supportExtendedCharacterFields){
+			adjustLengthForLongCharSupport(field);
+		}
 		return field;
 	}
 	

--- a/src/main/java/com/linuxense/javadbf/DBFHeader.java
+++ b/src/main/java/com/linuxense/javadbf/DBFHeader.java
@@ -65,7 +65,8 @@ public class DBFHeader {
 	private Charset detectedCharset;
 	private Charset usedCharset;
 
-
+        /** Flag indicating if 2-byte (extended) length character fields should be supported (see DBFField.adjustLengthForLongCharSupport(), default: true). */
+        private boolean supportExtendedCharacterFields = true;
 
 	private static final int DBASE_LEVEL_7 = 4;
 
@@ -123,14 +124,14 @@ public class DBFHeader {
 		DBFField field = null;
 		if (isDB7()) {
 			/* 48 each */
-			while ((field = DBFField.createFieldDB7(dataInput,this.usedCharset))!= null) {
+			while ((field = DBFField.createFieldDB7(dataInput,this.usedCharset, supportExtendedCharacterFields))!= null) {
 				v_fields.add(field);
 			}
 		}
 		else {
 			/* 32 each */
 			boolean useFieldFlags = supportsFieldFlags();
-			while ((field = DBFField.createField(dataInput,this.usedCharset, useFieldFlags))!= null) {				
+			while ((field = DBFField.createField(dataInput,this.usedCharset, useFieldFlags, supportExtendedCharacterFields))!= null) {				
 				v_fields.add(field);
 			}
 
@@ -306,4 +307,12 @@ public class DBFHeader {
 		this.usedCharset = charset;
 	}
 
+	/**
+	 * Sets whether 2-byte (extended) length character fields should be supported (see DBFField.adjustLengthForLongCharSupport(), default: true).
+	 * 
+	 * @param supportExtendedCharacterFields True to support extended fields
+	 */
+	public void setSupportExtendedCharacterFields(boolean supportExtendedCharacterFields) {
+		this.supportExtendedCharacterFields = supportExtendedCharacterFields;
+	}
 }

--- a/src/main/java/com/linuxense/javadbf/DBFReader.java
+++ b/src/main/java/com/linuxense/javadbf/DBFReader.java
@@ -214,11 +214,28 @@ public class DBFReader extends DBFBase implements Closeable {
 	 * @param showDeletedRows can be used to identify records that have been deleted.
 	 */
 	public DBFReader(InputStream in, Charset charset, boolean showDeletedRows) {
+		this(in, charset, showDeletedRows, true);
+	}
+
+	/**
+	 * Initializes a DBFReader object.
+	 *
+	 * When this constructor returns the object will have completed reading the
+	 * header (meta date) and header information can be queried there on. And it
+	 * will be ready to return the first row.
+	 *
+	 * @param in the InputStream where the data is read from.
+	 * @param charset charset used to decode field names and field contents. If null, then is autedetected from dbf file
+	 * @param showDeletedRows can be used to identify records that have been deleted.
+         * @param supportExtendedCharacterFields Defines whether 2-byte (extended) length character fields should be supported (see DBFField.adjustLengthForLongCharSupport(), default: true).
+	 */
+	public DBFReader(InputStream in, Charset charset, boolean showDeletedRows, boolean supportExtendedCharacterFields) {
 		try {
 			this.showDeletedRows = showDeletedRows;
 			this.inputStream = in;
 			this.dataInputStream = new DataInputStream(this.inputStream);
 			this.header = new DBFHeader();
+			this.header.setSupportExtendedCharacterFields(supportExtendedCharacterFields);
 			this.header.read(this.dataInputStream, charset, showDeletedRows);
 			setCharset(this.header.getUsedCharset());
 			/* it might be required to leap to the start of records at times */


### PR DESCRIPTION
We used the old JavaDBF library created by Anil Kumar to read DBF data for a long time and are planning to switch to your fork now.

Some time ago, MS-EXCEL was able to read and write DBF data (current versions can only read). So we have several files, where users used EXCEL to edit DBF data.

Unfortunately, EXCEL was not writing the DBF format correctly. We experienced the following:
- columns defined to contain numbers (e.g. N8.2) without any contents are "converted" to character (C) types.
- a character length was inserted (e.g. C8)
- the decimal count of the former numeric format was NOT reset to zero, resulting in an irregular type definition  (e.g C8.2).

DBFField.adjustLengthForLongCharSupport() added support for 2-byte length character fields (which was a 'hack' of some old PC programs).

This leads the DBFReader to crash because it now expects a large number of characters (520 in the example above).

I implemented a simple boolean flag to be able to turn off this 'feature' so that we can read mangled MS-EXCEL files without the support for the 'Clipper and FoxPro' data formats.

Please see column 'FLUGHOEHE' in the example DBF attached (which is read correctly by LibreOffice, for example):

[wrong-exented-character-field.zip](https://github.com/albfernandez/javadbf/files/4123645/wrong-exented-character-field.zip)


